### PR TITLE
Fix overriding all additional shipping drivers

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
+name             "papertrail"
 maintainer       "Librato, Inc."
 maintainer_email "mike@librato.com"
 license          "Apache 2.0"
 description      "Installs/Configures Sys Logging to papertrailapp.com"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.7"
-name             "papertrail"
+version          "1.0.0"
 
 depends          "rsyslog"
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -19,10 +19,14 @@ describe 'papertrail::default' do
     expect(chef_run).to render_file('/etc/rsyslog.d/60-watch-files.conf').with_content('$InputFileStateFile state_file_name_test_file')
   end
 
-  it 'uses attributes to generate configuration' do
+  it 'should use attributes to generate configuration' do
     expect(chef_run).to render_file('/etc/rsyslog.d/65-papertrail.conf').with_content('$ActionResumeRetryCount -1')
     expect(chef_run).to render_file('/etc/rsyslog.d/65-papertrail.conf').with_content('$ActionQueueMaxDiskSpace 100M')
     expect(chef_run).to render_file('/etc/rsyslog.d/65-papertrail.conf').with_content('$ActionQueueSize 100000')
     expect(chef_run).to render_file('/etc/rsyslog.d/65-papertrail.conf').with_content('$ActionQueueFileName papertrailqueue')
+  end
+
+  it 'should only set gtls transport for the current action' do
+    expect(chef_run).to render_file('/etc/rsyslog.d/65-papertrail.conf').with_content('$ActionSendStreamDriver gtls')
   end
 end

--- a/templates/default/papertrail.conf.erb
+++ b/templates/default/papertrail.conf.erb
@@ -2,7 +2,7 @@
 #
 
 $DefaultNetstreamDriverCAFile <%= @cert_file %> # trust these CAs
-$DefaultNetstreamDriver gtls # use gtls netstream driver
+$ActionSendStreamDriver gtls # use gtls netstream driver
 $ActionSendStreamDriverMode 1 # require TLS
 $ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
 $ActionSendStreamDriverPermittedPeer <%= node['papertrail']['permitted_peer'] %>


### PR DESCRIPTION
 Ensure gtls is only set for the current log to papertrail action.

Fixes the driver being changed for all subsequent log shipping.

Depends on #1 
